### PR TITLE
Add funding .yml file

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+https://www.patreon.com/elvanos

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,2 @@
-https://www.patreon.com/elvanos
+patreon:  elvanos
+github:  Elvanos


### PR DESCRIPTION
You'll need to enable funding in the GitHub settings for this to work, but this should make your Patreon visible on the sidebar.