### PR TITLE
Object Tree Scroll Fix

### DIFF
--- a/src/layouts/DocumentLayout.vue
+++ b/src/layouts/DocumentLayout.vue
@@ -141,6 +141,11 @@ export default class DocumentLayout extends BaseClass {
 </script>
 
 <style lang="scss">
+
+.sideWrapper{
+  height: calc(100% - 40px) !important;
+}
+
 .q-layout {
   outline: none !important;
 }


### PR DESCRIPTION
The drawer containing the object tree wasn't taking into account the styling of `top: 40px` being applied to itself when determining its internal height. This just quickly forces the drawer content containing the tree to take those `40px` into account.