### PR TITLE
Github Action to build different OS versions of FA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+# This is a basic workflow that is manually triggered
+
+name: Build App
+
+# Manually triggered
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version of the application being built'
+        required: true
+
+jobs:
+
+  # Builds all major OS versions of FA
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v2.3.4
+
+      
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v2.1.5
+      
+    - name: npm install and build
+      run: |
+        npm install
+        npm run build
+    
+    - name: Upload Linux Artifact
+      if: ${{ matrix.os }} == ubuntu-latest
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        # Artifact name
+        name: Linux_FA ${{ github.event.inputs.version }}
+        # A file, directory or wildcard pattern that describes what to upload
+        path: dist/electron/Packaged/*.AppImage
+        
+    - name: Upload MacOS Artifact
+      if: ${{ matrix.os }} == macOS-latest
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        # Artifact name
+        name: Linux_FA ${{ github.event.inputs.version }}
+        # A file, directory or wildcard pattern that describes what to upload
+        path: dist/electron/Packaged/*.dmg
+    
+    - name: Upload Windows Artifact
+      if: ${{ matrix.os }} == windows-latest
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        # Artifact name
+        name: Linux_FA ${{ github.event.inputs.version }}
+        # A file, directory or wildcard pattern that describes what to upload
+        path: dist/electron/Packaged/*.exe
+    

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         npm run build
     
     - name: Upload Linux Artifact
-      if: ${{ matrix.os == ubuntu-latest }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       uses: actions/upload-artifact@v2.2.3
       with:
         # Artifact name
@@ -42,7 +42,7 @@ jobs:
         path: dist/electron/Packaged/*.AppImage
         
     - name: Upload MacOS Artifact
-      if: ${{ matrix.os == macOS-latest }}
+      if: ${{ matrix.os == 'macOS-latest' }}
       uses: actions/upload-artifact@v2.2.3
       with:
         # Artifact name
@@ -51,7 +51,7 @@ jobs:
         path: dist/electron/Packaged/*.dmg
     
     - name: Upload Windows Artifact
-      if: ${{ matrix.os == windows-latest }}
+      if: ${{ matrix.os == 'windows-latest' }}
       uses: actions/upload-artifact@v2.2.3
       with:
         # Artifact name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,7 @@ jobs:
       with:
         # Artifact name
         name: Linux_FA ${{ github.event.inputs.version }}
-        # A file, directory or wildcard pattern that describes what to upload
-        path: dist/electron/Packaged/*.AppImage
+        path: dist/electron/Packaged/
         
     - name: Upload MacOS Artifact
       if: ${{ matrix.os == 'macOS-latest' }}
@@ -47,8 +46,7 @@ jobs:
       with:
         # Artifact name
         name: Mac_FA ${{ github.event.inputs.version }}
-        # A file, directory or wildcard pattern that describes what to upload
-        path: dist/electron/Packaged/*.dmg
+        path: dist/electron/Packaged/
     
     - name: Upload Windows Artifact
       if: ${{ matrix.os == 'windows-latest' }}
@@ -56,6 +54,5 @@ jobs:
       with:
         # Artifact name
         name: Windows_FA ${{ github.event.inputs.version }}
-        # A file, directory or wildcard pattern that describes what to upload
-        path: dist/electron/Packaged/*.exe
+        path: dist/electron/Packaged/
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         npm run build
     
     - name: Upload Linux Artifact
-      if: ${{ matrix.os }} == ubuntu-latest
+      if: ${{ matrix.os == ubuntu-latest }}
       uses: actions/upload-artifact@v2.2.3
       with:
         # Artifact name
@@ -42,20 +42,20 @@ jobs:
         path: dist/electron/Packaged/*.AppImage
         
     - name: Upload MacOS Artifact
-      if: ${{ matrix.os }} == macOS-latest
+      if: ${{ matrix.os == macOS-latest }}
       uses: actions/upload-artifact@v2.2.3
       with:
         # Artifact name
-        name: Linux_FA ${{ github.event.inputs.version }}
+        name: Mac_FA ${{ github.event.inputs.version }}
         # A file, directory or wildcard pattern that describes what to upload
         path: dist/electron/Packaged/*.dmg
     
     - name: Upload Windows Artifact
-      if: ${{ matrix.os }} == windows-latest
+      if: ${{ matrix.os == windows-latest }}
       uses: actions/upload-artifact@v2.2.3
       with:
         # Artifact name
-        name: Linux_FA ${{ github.event.inputs.version }}
+        name: Windows_FA ${{ github.event.inputs.version }}
         # A file, directory or wildcard pattern that describes what to upload
         path: dist/electron/Packaged/*.exe
     

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint --ext .js,.ts,.vue ./",
     "test": "echo \"No test specified\" && exit 0",
     "dev": "quasar dev -m electron",
-    "build": "quasar build -m electron"
+    "build": "quasar build -m electron -T all"
   },
   "dependencies": {
     "@quasar/extras": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint --ext .js,.ts,.vue ./",
     "test": "echo \"No test specified\" && exit 0",
     "dev": "quasar dev -m electron",
-    "build": "quasar build -m electron -T all"
+    "build": "quasar build -m electron"
   },
   "dependencies": {
     "@quasar/extras": "^1.0.0",


### PR DESCRIPTION
This is a github action that should build the different OS versions of FA (windows, linux, macOS). This is a manually triggered github action. 

I have installed the windows version produced from running this and it appears to work, but I have not checked macOS or Linux, but **All OS versions should be verified** to ensure this process will correctly produce the desired build artifacts.

You can trigger it by navigating to the "Actions" tab of the repository, selecting the "Build App" workflow in the left hand column. Once selected, you can trigger a build by selecting the Run Workflow button and entering in the version you want this build to be labeled (it is purely a label, it has no impact on the code actually compiled as this always takes the latest from the master branch). Once the builds have finished you can navigate to the summary of the workflow and scroll to the bottom to see the created artifacts. They currently are the entire built `dist/electron/Packaged` folder as I was unsure what entirely was needed for the build artifacts so I took everything.

You can see an example of the generated artifacts from a build I did while testing here (scroll to the bottom): [Test build](https://github.com/joffutt4/fantasia-archive/actions/runs/757563451)