### PR TITLE
Add document: link support to free text

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -102,7 +102,6 @@ import PouchDB from "pouchdb"
 import { OptionsStateInteface } from "./store/module-options/state"
 import { colors } from "quasar"
 import { tipsTricks } from "src/scripts/utilities/tipsTricks"
-import { shell } from "electron"
 import { summonAllPlusheForms } from "src/scripts/utilities/plusheMascot"
 import { saveCorkboard, retrieveCorkboard, retrieveCurrentProjectName } from "src/scripts/projectManagement/projectManagent"
 import documentPreview from "src/components/DocumentPreview.vue"
@@ -287,24 +286,9 @@ export default class App extends BaseClass {
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     if (event.target && event.target.tagName.toLowerCase() === "a" && event.target.closest(".fieldWysiwyg")) {
-      try {
-        // @ts-ignore
-        const url = new URL(event.target.href as string)
-        // @ts-ignore
-        console.log(url)
-        if (url.protocol === "http:" || url.protocol === "https:") {
-          shell.openExternal(url.href).catch(e => console.log(e))
-        }
-        else if (url.protocol === "document:") {
-          const doc = this.SGET_document(url.pathname)
-          /* eslint-disable */
-          this.openExistingDocumentRoute(doc)
-          /* eslint-enable */
-        }
-      }
-      catch (_) {
-
-      }
+      // @ts-ignore
+      this.openLink(event.target.href as string)
+      // @ts-ignore
     }
   }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -287,23 +287,23 @@ export default class App extends BaseClass {
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     if (event.target && event.target.tagName.toLowerCase() === "a" && event.target.closest(".fieldWysiwyg")) {
-      const isValidHttpUrl = (string:string) => {
-        let url
-
-        try {
-          url = new URL(string)
+      try {
+        // @ts-ignore
+        const url = new URL(event.target.href as string)
+        // @ts-ignore
+        console.log(url)
+        if (url.protocol === "http:" || url.protocol === "https:") {
+          shell.openExternal(url.href).catch(e => console.log(e))
         }
-        catch (_) {
-          return false
+        else if (url.protocol === "document:") {
+          const doc = this.SGET_document(url.pathname)
+          /* eslint-disable */
+          this.openExistingDocumentRoute(doc)
+          /* eslint-enable */
         }
-
-        return url.protocol === "http:" || url.protocol === "https:"
       }
+      catch (_) {
 
-      // @ts-ignore
-      if (isValidHttpUrl(event.target.href)) {
-      // @ts-ignore
-        shell.openExternal(event.target.href).catch(e => console.log(e))
       }
     }
   }

--- a/src/BaseClass.ts
+++ b/src/BaseClass.ts
@@ -9,6 +9,7 @@ import { uid, colors, extend } from "quasar"
 import { I_FieldRelationship } from "src/interfaces/I_FieldRelationship"
 import { I_KeyPressObject } from "src/interfaces/I_KeypressObject"
 import { ProjectInterface } from "./store/module-project/state"
+import { shell } from "electron"
 
 const Blueprints = namespace("blueprintsModule")
 const AllDocuments = namespace("allDocumentsModule")
@@ -677,5 +678,26 @@ export default class BaseClass extends Vue {
 
       return hasLegacyValue
     })
+  }
+
+  openLink (link: string) {
+    try {
+      // @ts-ignore
+      const url = new URL(link)
+      // @ts-ignore
+      console.log(url)
+      if (url.protocol === "http:" || url.protocol === "https:") {
+        shell.openExternal(url.href).catch(e => console.log(e))
+      }
+      else if (url.protocol === "document:") {
+        const doc = this.SGET_document(url.pathname)
+        /* eslint-disable */
+        this.openExistingDocumentRoute(doc)
+        /* eslint-enable */
+      }
+    }
+    catch (_) {
+
+    }
   }
 }

--- a/src/components/dialogs/ExistingDocument.vue
+++ b/src/components/dialogs/ExistingDocument.vue
@@ -241,7 +241,7 @@
 
 <script lang="ts">
 
-import { Component, Watch } from "vue-property-decorator"
+import { Component, Emit, Prop, Watch } from "vue-property-decorator"
 import { I_OpenedDocument, I_ShortenedDocument } from "src/interfaces/I_OpenedDocument"
 import { advancedDocumentFilter } from "src/scripts/utilities/advancedDocumentFilter"
 import { extend, uid } from "quasar"
@@ -260,6 +260,10 @@ import documentPreview from "src/components/DocumentPreview.vue"
   }
 })
 export default class ExistingDocumentDialog extends DialogBase {
+  @Prop({
+    default: false
+  }) readonly preventOpen!: boolean
+
   /****************************************************************/
   // DIALOG CONTROL
   /****************************************************************/
@@ -490,6 +494,17 @@ export default class ExistingDocumentDialog extends DialogBase {
   openExistingInput (e: I_ShortenedDocument) {
     // @ts-ignore
     e = (Array.isArray(e)) ? e[0] : e
+
+    // Signal to any listeners that care about this document being opened
+    this.signalDocumentSelected(e._id)
+
+    // If the caller doesn't want to open the document, don't actually open the document
+    if (this.preventOpen) {
+      this.dialogModel = false
+      this.existingDocumentModel = []
+
+      return
+    }
     // Open document and close dialog
     if (!this.disableCloseAftertSelectQuickSearch) {
       this.dialogModel = false
@@ -617,6 +632,12 @@ export default class ExistingDocumentDialog extends DialogBase {
     await this.sleep(100)
 
     this.SSET_setExportDialogState([node._id])
+  }
+
+  // Runs when a document would be opened by this dialog
+  @Emit()
+  signalDocumentSelected (document: string) {
+    return document
   }
 }
 </script>

--- a/src/components/fields/Field_Wysiwyg.vue
+++ b/src/components/fields/Field_Wysiwyg.vue
@@ -170,6 +170,7 @@ export default class Field_Wysiwyg extends FieldBase {
    * Wysiwyg toolbar ontions
    */
   wysiwygOptions = [
+    ["link"],
     ["left", "center", "right", "justify"],
     ["bold", "italic", "underline", "subscript", "superscript"],
     [

--- a/src/components/fields/Field_Wysiwyg.vue
+++ b/src/components/fields/Field_Wysiwyg.vue
@@ -170,7 +170,6 @@ export default class Field_Wysiwyg extends FieldBase {
    * Wysiwyg toolbar ontions
    */
   wysiwygOptions = [
-    ["link"],
     ["left", "center", "right", "justify"],
     ["bold", "italic", "underline", "subscript", "superscript"],
     [


### PR DESCRIPTION
This PR tries to enable link support for free text blocks.

Creating an `<a href="document:DOCUMENT_ID">SomeText</a>` will produce the below effect (see video).

https://github.com/Elvanos/fantasia-archive/assets/5565094/a5e78ca0-dc21-46cb-9875-389fc33c6832

You can also type the `@` key and have a document browser appear and you can insert a link to a specific document from there, see second video)

https://github.com/Elvanos/fantasia-archive/assets/5565094/1c3f377e-a6f7-469f-b10d-ed34f4b25945

