### PR TITLE
Try to fix the inserted new-lines for the new inline links in PDF export

### DIFF
--- a/src/components/dialogs/ExportProject.vue
+++ b/src/components/dialogs/ExportProject.vue
@@ -1974,13 +1974,14 @@ export default class ExportProject extends DialogBase {
         node.attrs.hasHeadingFontSize = false
       }
 
-      // If next if bold, italic or underline
+      // If next if bold, italic, underline or link
       if (nextNode) {
         if ((nextNode.type === "tag" && nextNode.name === "i") ||
         (nextNode.type === "tag" && nextNode.name === "b") ||
         (nextNode.type === "tag" && nextNode.name === "u") ||
         (nextNode.type === "tag" && nextNode.name === "font") ||
-        (nextNode.type === "tag" && nextNode.name === "span")
+        (nextNode.type === "tag" && nextNode.name === "span") ||
+        (nextNode.type === "tag" && nextNode.name === "a")
         ) {
           node.attrs.continued = true
         }
@@ -2004,6 +2005,15 @@ export default class ExportProject extends DialogBase {
       }
       else {
         node.attrs.isSpan = false
+      }
+
+      // Fix for a tags
+      if ((node.type === "tag" && node.name === "a") || node?.parentNode?.attrs.isLink === true) {
+        node.attrs.isLink = true
+        node.attrs.continued = true
+      }
+      else {
+        node.attrs.isLink = false
       }
 
       // Text modifier - Italic
@@ -2085,7 +2095,7 @@ export default class ExportProject extends DialogBase {
         const returnNode = node
         // @ts-ignore
         returnNode.content = returnNode.content
-          .replace(/&nbsp;/g, "")
+          .replace(/&nbsp;/g, " ")
           .replace(/(\r\n|\n|\r)/gm, "")
           .replace(/&amp;/g, "&")
 


### PR DESCRIPTION
Using the following while testing: 
```
<div><a href="document:22019f22-9623-42cc-a2da-f588723df63a">Aelithia</a>&nbsp;with&nbsp;<a href="document:fdb5af78-d28c-40f2-86e3-8bb46251c61f">Sorineth</a>&nbsp;stood ground on the edge of the bridge waiting for</div>
```

Exporting with the current release version of FA results in the following:
![image](https://github.com/Elvanos/fantasia-archive/assets/5565094/ee7c52c6-55d3-4c84-9ac8-9039fa7e19ff)

This PR aims to fix the added newlines around the `a` tags. I haven't had much time to test this thoroughly / on larger text. (it could handle my session notes tho)
After this PR the output of the above text looks like this:
![image](https://github.com/Elvanos/fantasia-archive/assets/5565094/7ab9f426-cc14-41d6-ab45-c819e5187db3)


**Please note:** maybe the most dangerous change here is `replace(/&nbsp;/g, " ")` .